### PR TITLE
Enum refactoring

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: isort
         args: [
             --combine-as,
-            --line-length=100,
+            --line-length=120,
             --ensure-newline-before-comments,
             --single-line-exclusions=typing,
             --trailing-comma,

--- a/betfair_parser/spec/api/betting.py
+++ b/betfair_parser/spec/api/betting.py
@@ -1,8 +1,8 @@
 from typing import List, Literal, Optional, Union
 
-from betfair_parser.constants import OrderResponse, OrderSide, OrderStatus, OrderType
 from betfair_parser.spec.api.core import RequestBase
 from betfair_parser.spec.common import BaseMessage
+from betfair_parser.spec.constants import OrderResponse, OrderSide, OrderStatus, OrderType
 
 
 # ------------ ORDER TYPES ------------ #

--- a/betfair_parser/spec/api/error.py
+++ b/betfair_parser/spec/api/error.py
@@ -1,4 +1,4 @@
-from betfair_parser.spec.common import BaseMessage
+from betfair_parser.spec.common import BaseMessage, DocumentedEnum, doc
 
 
 class Error:
@@ -8,3 +8,90 @@ class Error:
 
 class ErrorResponse(BaseMessage, frozen=True):
     error: Error
+
+
+class APIExceptionCodes(DocumentedEnum):
+    TOO_MUCH_DATA = doc("The operation requested too much data")
+    INVALID_INPUT_DATA = doc("Invalid input data")
+    INVALID_SESSION_INFORMATION = doc("The session token passed is invalid or expired")
+    NO_APP_KEY = doc("An application key is required for this operation")
+    NO_SESSION = doc("A session token is required for this operation")
+    UNEXPECTED_ERROR = doc("An unexpected internal error occurred that prevented successful request processing.")
+    INVALID_APP_KEY = doc("The application key passed is invalid")
+    TOO_MANY_REQUESTS = doc("There are too many pending requests")
+    SERVICE_BUSY = doc("The service is currently too busy to service this request")
+    TIMEOUT_ERROR = doc("Internal call to downstream service timed out")
+    REQUEST_SIZE_EXCEEDS_LIMIT = doc(
+        "The request exceeds the request size limit. Requests are limited to a total of 250"
+        "betId's/marketId's (or a combination of both)"
+    )
+    ACCESS_DENIED = doc(
+        "The calling client is not permitted to perform the specific action e.g. the using a Delayed "
+        "App Key when placing bets or attempting to place a bet from a restricted jurisdiction."
+    )
+
+
+class LoginExceptionCodes(DocumentedEnum):
+    INVALID_USERNAME_OR_PASSWORD = doc("the username or password are invalid")
+    ACCOUNT_NOW_LOCKED = doc("the account was just locked")
+    ACCOUNT_ALREADY_LOCKED = doc("the account is already locked")
+    PENDING_AUTH = doc("pending authentication")
+    TELBET_TERMS_CONDITIONS_NA = doc("Telbet terms and conditions rejected")
+    DUPLICATE_CARDS = doc("duplicate cards")
+    SECURITY_QUESTION_WRONG_3X = doc("the user has entered wrong the security answer 3 times")
+    KYC_SUSPEND = doc("KYC suspended")
+    SUSPENDED = doc("the account is suspended")
+    CLOSED = doc("the account is closed")
+    SELF_EXCLUDED = doc("the account has been self-excluded")
+    INVALID_CONNECTIVITY_TO_REGULATOR_DK = doc(
+        "the DK regulator cannot be accessed due to some internal problems in the system behind or in "
+        "at regulator; timeout cases included."
+    )
+    NOT_AUTHORIZED_BY_REGULATOR_DK = doc(
+        "the user identified by the given credentials is not authorized in the DK's jurisdictions due to the "
+        "regulators' policies. Ex: the user for which this session should be created is not allowed to "
+        "act(play, bet) in the DK's jurisdiction."
+    )
+    INVALID_CONNECTIVITY_TO_REGULATOR_IT = doc(
+        "the IT regulator cannot be accessed due to some internal problems in the system behind or in at "
+        "regulator; timeout cases included."
+    )
+    NOT_AUTHORIZED_BY_REGULATOR_IT = doc(
+        "the user identified by the given credentials is not authorized in the IT's jurisdictions due to the "
+        "regulators' policies. Ex: the user for which this session should be created is not allowed to "
+        "act(play, bet) in the IT's jurisdiction."
+    )
+    SECURITY_RESTRICTED_LOCATION = doc("the account is restricted due to security concerns")
+    BETTING_RESTRICTED_LOCATION = doc("the account is accessed from a location where betting is restricted")
+    TRADING_MASTER = doc("Trading Master Account")
+    TRADING_MASTER_SUSPENDED = doc("Suspended Trading Master Account")
+    AGENT_CLIENT_MASTER = doc("Agent Client Master")
+    AGENT_CLIENT_MASTER_SUSPENDED = doc("Suspended Agent Client Master")
+    DANISH_AUTHORIZATION_REQUIRED = doc("Danish authorization required")
+    SPAIN_MIGRATION_REQUIRED = doc("Spain migration required")
+    DENMARK_MIGRATION_REQUIRED = doc("Denmark migration required")
+    SPANISH_TERMS_ACCEPTANCE_REQUIRED = doc("The latest Spanish terms and conditions version must be accepted")
+    ITALIAN_CONTRACT_ACCEPTANCE_REQUIRED = doc("The latest Italian contract version must be accepted")
+    CERT_AUTH_REQUIRED = doc("Certificate required or certificate present but could not authenticate with it")
+    CHANGE_PASSWORD_REQUIRED = doc("change password required")
+    PERSONAL_MESSAGE_REQUIRED = doc("personal message required for the user")
+    INTERNATIONAL_TERMS_ACCEPTANCE_REQUIRED = doc(
+        "The latest international terms and conditions must be accepted prior to logging in."
+    )
+    EMAIL_LOGIN_NOT_ALLOWED = doc("This account has not opted in to log in with the email")
+    MULTIPLE_USERS_WITH_SAME_CREDENTIAL = doc("There is more than one account with the same credential")
+    ACCOUNT_PENDING_PASSWORD_CHANGE = doc("The account must undergo password recovery to reactivate")
+
+
+class JSONException(DocumentedEnum):
+    INVALID_JSON = doc(
+        value=-32700,
+        docstring=(
+            "Invalid JSON was received by the server. An error occurred on the server while " "parsing the JSON text."
+        ),
+    )
+    METHOD_NOT_FOUND = doc(value=-32601, docstring="Method not found")
+    INVALID_PARAMETERS = doc(
+        value=-32602, docstring="Problem parsing the parameters, or a mandatory parameter was not found"
+    )
+    JSON_RPC_ERROR = doc(value=-32603, docstring="Internal JSON-RPC error")

--- a/betfair_parser/spec/common.py
+++ b/betfair_parser/spec/common.py
@@ -1,3 +1,5 @@
+from enum import Enum, auto
+
 import msgspec
 
 
@@ -7,3 +9,82 @@ class BaseMessage(msgspec.Struct, kw_only=True, forbid_unknown_fields=True, froz
 
     def to_dict(self):
         return {f: getattr(self, f) for f in self.__struct_fields__}
+
+
+class StrEnum(str, Enum):
+    """Allow the `auto()` syntax to use the defined enum key as value.
+
+    Unlike in python 3.11 StrEnum, the fieldnames are not lowered.
+
+    class MyEnum(BaseEnum):
+        FIELD = auto()
+
+    >>> MyEnum.FIELD.value == "FIELD"
+    True
+    """
+
+    def _generate_next_value_(key, start, count, last_values):
+        return key
+
+
+class doc(auto):
+    """Auto-generated enum field with docstring
+
+    doc("docstring") replaces auto() for DocumentedEnums. A value
+    can be set using doc(value=..., docstring=...), otherwise the
+    same value as for auto() is calculated.
+
+    This mechanism only works in combination with
+    DocumentedEnum and messes up the values of an Enum otherwise.
+    """
+
+    def __init__(self, docstring=None, value=None):
+        self._value = value
+        self.__doc__ = docstring
+
+    @property
+    def value(self):
+        # When value is accessed the first time by the enum internals, it
+        # needs to return auto.value, in order to trigger the auto-generation
+        # mechanism.
+        if self._value is None:
+            return auto.value
+        return self
+
+    @value.setter
+    def value(self, val):
+        # value is set by the enum auto-generation mechanism
+        self._value = val
+
+
+class DocumentedEnum(Enum):
+    """Enum with documentation strings.
+
+    class DocEnum(DocumentedEnum):
+        FIELD = doc("This is a docstring")
+        FIELD2 = auto()
+
+    >>> DocEnum.FIELD == "FIELD"
+    True
+    >>> DocEnum.FIELD.__doc__
+    "This is a docstring"
+    """
+
+    def __new__(cls, val):
+        member = object.__new__(cls)
+        if isinstance(val, doc):
+            member._value_ = val._value
+            member.__doc__ = val.__doc__
+        else:
+            # also handle ordinary or auto() values
+            member._value = val
+            member.__doc__ = None
+        return member
+
+    def _generate_next_value_(key, start, count, last_values):
+        return key
+
+    def __str__(self):
+        if self.__doc__:
+            return f"{super().__str__()}: {self.__doc__}"
+        return super().__str__()

--- a/betfair_parser/spec/common.py
+++ b/betfair_parser/spec/common.py
@@ -1,4 +1,4 @@
-from enum import Enum, auto
+from enum import Enum, _auto_null, auto  # noqa
 
 import msgspec
 
@@ -48,7 +48,7 @@ class doc(auto):
         # needs to return auto.value, in order to trigger the auto-generation
         # mechanism.
         if self._value is None:
-            return auto.value
+            return _auto_null
         return self
 
     @value.setter

--- a/betfair_parser/spec/constants.py
+++ b/betfair_parser/spec/constants.py
@@ -1,4 +1,6 @@
-from enum import Enum
+from enum import auto
+
+from betfair_parser.spec.common import StrEnum
 
 
 EVENT_TYPE_TO_NAME = {
@@ -32,21 +34,21 @@ EVENT_TYPE_TO_NAME = {
 }
 
 
-class OrderType(Enum):
-    LIMIT = "LIMIT"
-    MARKET_ON_CLOSE = "MARKET_ON_CLOSE"
+class OrderType(StrEnum):
+    LIMIT = auto()
+    MARKET_ON_CLOSE = auto()
 
 
-class OrderSide(Enum):
-    BACK = "BACK"
-    LAY = "LAY"
+class OrderSide(StrEnum):
+    BACK = auto()
+    LAY = auto()
 
 
-class OrderResponse(Enum):
-    SUCCESS = "SUCCESS"
-    FAILURE = "FAILURE"
+class OrderResponse(StrEnum):
+    SUCCESS = auto()
+    FAILURE = auto()
 
 
-class OrderStatus(Enum):
-    EXECUTABLE = "EXECUTABLE"
-    EXECUTION_COMPLETE = "EXECUTION_COMPLETE"
+class OrderStatus(StrEnum):
+    EXECUTABLE = auto()
+    EXECUTION_COMPLETE = auto()

--- a/betfair_parser/spec/streaming/mcm.py
+++ b/betfair_parser/spec/streaming/mcm.py
@@ -1,25 +1,25 @@
 import datetime
-from enum import Enum
+from enum import auto
 from typing import List, Literal, Optional, Union
 
-from betfair_parser.constants import EVENT_TYPE_TO_NAME
 from betfair_parser.spec.api.markets import PriceLadderDescription
-from betfair_parser.spec.common import BaseMessage
+from betfair_parser.spec.common import BaseMessage, StrEnum
+from betfair_parser.spec.constants import EVENT_TYPE_TO_NAME
 
 
-class RunnerStatus(Enum):
-    ACTIVE = "ACTIVE"
-    REMOVED = "REMOVED"
-    WINNER = "WINNER"
-    PLACED = "PLACED"
-    LOSER = "LOSER"
-    HIDDEN = "HIDDEN"
+class RunnerStatus(StrEnum):
+    ACTIVE = auto()
+    REMOVED = auto()
+    WINNER = auto()
+    PLACED = auto()
+    LOSER = auto()
+    HIDDEN = auto()
 
 
-class MarketStatus(Enum):
-    OPEN = "OPEN"
-    SUSPENDED = "SUSPENDED"
-    CLOSED = "CLOSED"
+class MarketStatus(StrEnum):
+    OPEN = auto()
+    SUSPENDED = auto()
+    CLOSED = auto()
 
 
 class RunnerValues(BaseMessage, frozen=True):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ fsspec = ">=2022"
 pytest = "^7.1"
 pytest-benchmark = "^4.0"
 
+[tool.black]
+line-length = 120
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,16 @@ pytest-benchmark = "^4.0"
 [tool.black]
 line-length = 120
 
+[tool.isort]
+line_length = 120
+ensure_newline_before_comments = true
+single_line_exclusions = "typing"
+multi_line_output = 3
+lines_after_imports = 2
+use_parentheses = true
+include_trailing_comma = true
+combine_as_imports = true
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/unit/api/test_betting.py
+++ b/tests/unit/api/test_betting.py
@@ -1,12 +1,7 @@
 import msgspec.json
 import pytest
 
-from betfair_parser.spec.api.betting import (
-    PlaceResultResponse,
-    cancelOrders,
-    placeOrders,
-    replaceOrders,
-)
+from betfair_parser.spec.api.betting import PlaceResultResponse, cancelOrders, placeOrders, replaceOrders
 from tests.resources import id_from_path, read_test_file
 
 

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -1,0 +1,47 @@
+from enum import auto
+
+import msgspec
+
+from betfair_parser.spec.common import DocumentedEnum, StrEnum, doc
+
+
+def test_strenum():
+    class SE(StrEnum):
+        FIELD1 = auto()
+        FIELD2 = "xyz"
+
+    assert SE.FIELD1 == "FIELD1"
+    assert SE.FIELD2 == "xyz"
+
+
+def test_documented_enum():
+    class DE(DocumentedEnum):
+        FIELD_AUTO = auto()
+        FIELD_DOC = doc("This is a docstring")
+        FIELD_DOC_VALUE = doc(value="doc_val", docstring="This is another docstring")
+        FIELD_VAL = "SOME_VALUE"
+
+    assert DE.FIELD_AUTO.value == "FIELD_AUTO"
+    assert DE.FIELD_AUTO.__doc__ is None
+    assert DE.FIELD_DOC.value == "FIELD_DOC"
+    assert DE.FIELD_DOC.__doc__ == "This is a docstring"
+    assert DE.FIELD_DOC_VALUE.value == "doc_val"
+    assert DE.FIELD_DOC_VALUE.__doc__ == "This is another docstring"
+    assert DE.FIELD_VAL.value == "SOME_VALUE"
+    assert DE.FIELD_VAL.__doc__ is None
+
+    assert DE("FIELD_AUTO") == DE.FIELD_AUTO
+    assert set(DE._value2member_map_.keys()) == {"FIELD_AUTO", "FIELD_DOC", "doc_val", "SOME_VALUE"}
+    assert msgspec.json.decode(msgspec.json.encode(DE.FIELD_DOC_VALUE), type=DE) == DE.FIELD_DOC_VALUE
+
+
+def test_documented_enum_int():
+    class IE(DocumentedEnum):
+        FIELD1 = doc(value=1, docstring="Some docstring")
+        FIELD2 = doc(value=10, docstring="Another docstring")
+
+    assert IE.FIELD1.value == 1
+    assert IE.FIELD1.__doc__ == "Some docstring"
+    assert IE.FIELD2.value == 10
+    assert IE.FIELD2.__doc__ == "Another docstring"
+    assert msgspec.json.decode(msgspec.json.encode(IE.FIELD1), type=IE) == IE.FIELD1


### PR DESCRIPTION
- Added a `StrEnum` type to avoid `FIELDNAME = "FIELDNAME"` assignments and have that done by `auto()` instead.
- Added `DocumentedEnum` that can hold enum instances with a docstring, that can get used for more descriptive error messages.