### PR TITLE
More usable request objects

### DIFF
--- a/betfair_parser/client.py
+++ b/betfair_parser/client.py
@@ -59,5 +59,7 @@ def cert_login(session, username, password, app_key, endpoints=ENDPOINTS):
 
 
 def logout(session, endpoints=ENDPOINTS):
-    request(session, Logout(), endpoints=endpoints)
-    del session.headers["X-Authentication"]
+    try:
+        request(session, Logout(), endpoints=endpoints)
+    finally:
+        session.headers.pop("X-Authentication", None)

--- a/betfair_parser/spec/common/messages.py
+++ b/betfair_parser/spec/common/messages.py
@@ -36,6 +36,9 @@ class BaseMessage(msgspec.Struct, kw_only=True, forbid_unknown_fields=True, froz
     def to_dict(self):
         return msgspec.structs.asdict(self)
 
+    def replace(self, **kwargs):
+        return msgspec.structs.replace(self, **kwargs)
+
 
 class Params(BaseMessage, omit_defaults=True, frozen=True):
     """By default, don't send None and other default values in operation parameters."""


### PR DESCRIPTION
Reusing request frozen objects e.g. in a loop when just changing single parameters was a bit of a pain. It might make sense to unfreeze them at some point. The patch adds a replace method to the message objects, just like in named tuples, which at least makes the frozen objects easier handle and to create modified copies of them.

If you could push a release with that change, would be great.