### PR TITLE
Simplify pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,11 +51,6 @@ repos:
     hooks:
       - id: ruff
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
-    hooks:
-      - id: pyupgrade
-
   - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
     rev: 0.2.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,12 +30,6 @@ repos:
         additional_dependencies:
           - tomli
 
-  - repo: https://github.com/hadialqattan/pycln
-    rev: v2.3.0
-    hooks:
-      - id: pycln
-        name: pycln (Python unused imports)
-
   - repo: https://github.com/psf/black
     rev: 23.9.1
     hooks:

--- a/betfair_parser/spec/streaming/messages.py
+++ b/betfair_parser/spec/streaming/messages.py
@@ -4,7 +4,7 @@ Definition of the betfair streaming API messages as defined in:
 - https://github.com/betfair/stream-api-sample-code/blob/master/ESASwaggerSchema.json
  """
 
-from typing import List, Literal, Optional, Union
+from typing import Literal, Optional, Union
 
 from betfair_parser.spec.common import BaseMessage
 from betfair_parser.spec.streaming.enums import ChangeType, SegmentType, StatusErrorCode
@@ -132,7 +132,7 @@ class MCM(_ChangeMessage, kw_only=True, frozen=True):
     Market subscriptions are always in the underlying exchange currency - GBP.
     """
 
-    mc: Optional[List[MarketChange]] = None
+    mc: Optional[list[MarketChange]] = None
 
     @property
     def market_changes(self):
@@ -146,7 +146,7 @@ class OCM(_ChangeMessage, kw_only=True, frozen=True):
     Order subscriptions are provided in the currency of the account that the orders are placed in.
     """
 
-    oc: Optional[List[OrderMarketChange]] = None
+    oc: Optional[list[OrderMarketChange]] = None
 
     @property
     def order_market_changes(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ check_untyped_defs = true
 
 [tool.ruff]
 fix = false
+extend-select = ["UP"]
 line-length = 120
 
 [tool.ruff.per-file-ignores]


### PR DESCRIPTION
Unused imports are currently checked anyways with `ruff`, so save some CPU cycles and dependency issues and remove `pycln`. `ruff` now also replaces `pyupgrade`.