### PR TITLE
Fix CertLogin

### DIFF
--- a/betfair_parser/spec/identity.py
+++ b/betfair_parser/spec/identity.py
@@ -184,7 +184,7 @@ class CertLoginResponse(BaseResponse, frozen=True):
         return self.status != LoginExceptionCode.SUCCESS
 
 
-class CertLogin(_IdentityRequest, kw_only=True, frozen=True):
+class CertLogin(_IdentityRequest, kw_only=True, frozen=True, tag=str.lower):
     # Subclassing Login would have been more obvious, but then mypy freaks out
     # due to a different return_type
 

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -2,7 +2,7 @@ import pytest
 
 from betfair_parser.endpoints import ENDPOINTS
 from betfair_parser.spec.common import first_lower
-from betfair_parser.spec.identity import KeepAlive, LoginResponse, Logout
+from betfair_parser.spec.identity import CertLogin, KeepAlive, LoginResponse, Logout
 
 
 @pytest.mark.parametrize("msg", [KeepAlive(), KeepAlive.with_params(), Logout(), Logout.with_params()])
@@ -14,10 +14,17 @@ def test_request_init(msg):
     """
     assert msg.method == first_lower(type(msg).__name__)
     assert not msg.body()
-    assert ENDPOINTS.url_for_request(msg).lower().endswith(f"/api/{type(msg).__name__.lower()}")
+    assert ENDPOINTS.url_for_request(msg).endswith(f"/api/{first_lower(type(msg).__name__)}")
     assert msg.validate()
 
 
 def test_login_response():
     resp = b'{"token":"","product":"","status":"FAIL","error":"INPUT_VALIDATION_ERROR"}'
     assert LoginResponse.parse(resp)
+
+
+def test_certlogin():
+    """CertLogin is the only method, that doesn't use camelCase for the method name."""
+    msg = CertLogin.with_params(username="asdf", password="test")
+    assert msg.method == type(msg).__name__.lower()
+    assert ENDPOINTS.url_for_request(msg).endswith(f"/api/{type(msg).__name__.lower()}")


### PR DESCRIPTION
"certlogin" is the only endpoint method not camel cased ... fixed and test case added. Shame on me for lousy testing.