### PR TITLE
Omit useless default values for requests and object representations

### DIFF
--- a/betfair_parser/spec/accounts/operations.py
+++ b/betfair_parser/spec/accounts/operations.py
@@ -20,7 +20,7 @@ class _AccountRequest(Request, frozen=True, tag_field="method", tag=accounts_tag
     throws = AccountAPINGException
 
 
-class _GetAccountFundsParams(Params, frozen=True):
+class _GetAccountFundsParams(Params, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     wallet: Optional[Wallet] = None  # Name of the wallet in question. Global wallet is returned by default
 
 
@@ -38,7 +38,7 @@ class GetAccountDetails(_AccountRequest, kw_only=True, frozen=True):
     return_type = Response[AccountDetailsResponse]
 
 
-class _GetAccountStatementParams(Params, frozen=True):
+class _GetAccountStatementParams(Params, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     locale: Optional[str] = None  # The language to be used where applicable. Defaults to account settings
     from_record: Optional[int] = None  # Specifies the first record that will be returned, defaults to 0
     record_count: Optional[int] = None  # Specifies the maximum number of records to be returned. Maximum 100
@@ -60,7 +60,7 @@ class GetAccountStatement(_AccountRequest, kw_only=True, frozen=True):
     return_type = Response[AccountStatementReport]
 
 
-class _ListCurrencyRatesParams(Params, frozen=True):
+class _ListCurrencyRatesParams(Params, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     from_currency: Optional[str] = None  # The currency from which the rates are computed. Only GBP for now.
 
 

--- a/betfair_parser/spec/accounts/type_definitions.py
+++ b/betfair_parser/spec/accounts/type_definitions.py
@@ -11,7 +11,7 @@ from betfair_parser.spec.accounts.enums import (
 from betfair_parser.spec.common import BaseMessage, Date
 
 
-class ApplicationSubscription(BaseMessage, frozen=True):
+class ApplicationSubscription(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Application subscription details"""
 
     subscription_token: str  # Application key identifier
@@ -25,7 +25,7 @@ class ApplicationSubscription(BaseMessage, frozen=True):
     vendor_client_id: Optional[str] = None
 
 
-class SubscriptionHistory(BaseMessage, frozen=True):
+class SubscriptionHistory(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Application subscription history details"""
 
     subscription_token: str  # Application key identifier
@@ -38,7 +38,7 @@ class SubscriptionHistory(BaseMessage, frozen=True):
     client_reference: Optional[str] = None
 
 
-class SubscriptionTokenInfo(BaseMessage, frozen=True):
+class SubscriptionTokenInfo(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Subscription token information"""
 
     subscription_token: str
@@ -49,7 +49,7 @@ class SubscriptionTokenInfo(BaseMessage, frozen=True):
     subscription_status: Optional[SubscriptionStatus] = None
 
 
-class AccountSubscription(BaseMessage, frozen=True):
+class AccountSubscription(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Application subscription details"""
 
     subscription_tokens: list[SubscriptionTokenInfo]
@@ -57,7 +57,7 @@ class AccountSubscription(BaseMessage, frozen=True):
     application_version_id: Optional[str] = None
 
 
-class DeveloperAppVersion(BaseMessage, frozen=True):
+class DeveloperAppVersion(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Describes a version of an external application"""
 
     owner: str  # The user who owns the specific version of the application
@@ -91,7 +91,7 @@ class DeveloperApp(BaseMessage, frozen=True):
     app_versions: list[DeveloperAppVersion]  # The application versions (including application keys)
 
 
-class AccountFundsResponse(BaseMessage, frozen=True):
+class AccountFundsResponse(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Response for retrieving available to bet."""
 
     available_to_bet_balance: Optional[float] = None
@@ -108,7 +108,7 @@ class AccountFundsResponse(BaseMessage, frozen=True):
     wallet: Optional[Wallet] = None
 
 
-class AccountDetailsResponse(BaseMessage, frozen=True):
+class AccountDetailsResponse(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Response for Account details."""
 
     # Default user currency Code. See Currency Parameters for minimum bet sizes relating to each currency.
@@ -129,7 +129,7 @@ class AccountDetailsResponse(BaseMessage, frozen=True):
     country_code: Optional[str] = None  # The customer's country of residence (ISO 2 Char format)
 
 
-class StatementLegacyData(BaseMessage, frozen=True):
+class StatementLegacyData(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Summary of a cleared order."""
 
     avg_price: Optional[float]  # The average matched price of the bet (null if no part has been matched)
@@ -171,7 +171,7 @@ class StatementLegacyData(BaseMessage, frozen=True):
     avg_price_raw: Optional[float] = None
 
 
-class StatementItem(BaseMessage, kw_only=True, frozen=True):
+class StatementItem(BaseMessage, kw_only=True, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Summary of a cleared order."""
 
     # An external reference, eg. equivalent to betId in the case of an exchange bet statement item.
@@ -200,7 +200,7 @@ class AccountStatementReport(BaseMessage, frozen=True):
     more_available: bool  # Indicates whether there are further result items beyond this page.
 
 
-class CurrencyRate(BaseMessage, frozen=True):
+class CurrencyRate(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     currency_code: Optional[str] = None  # Three-letter ISO 4217 code
     rate: Optional[float] = None  # Exchange rate for the currency specified in the request
 
@@ -212,7 +212,7 @@ class AuthorisationResponse(BaseMessage, frozen=True):
     redirect_url: str  # URL to redirect the user to the vendor page
 
 
-class SubscriptionOptions(BaseMessage, frozen=True, rename=None):
+class SubscriptionOptions(BaseMessage, frozen=True, omit_defaults=True, repr_omit_defaults=True, rename=None):
     # No rename: SubscriptionOption fields don't use camelCase in Betfair API
 
     """Wrapper object containing details of how a subscription should be created"""
@@ -244,7 +244,7 @@ class VendorAccessTokenInfo(BaseMessage, frozen=True, rename=None):
     application_subscription: ApplicationSubscription
 
 
-class VendorDetails(BaseMessage, frozen=True):
+class VendorDetails(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Wrapper object containing vendor name and redirect url"""
 
     app_version_id: int  # Internal id of the application

--- a/betfair_parser/spec/betting/listings.py
+++ b/betfair_parser/spec/betting/listings.py
@@ -35,7 +35,7 @@ from betfair_parser.spec.common import (
 )
 
 
-class _ListingParams(Params, frozen=True):
+class _ListingParams(Params, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     filter: MarketFilter
     locale: Optional[str] = None
 
@@ -106,7 +106,7 @@ class ListVenues(_ListingRequest, kw_only=True, frozen=True):
 # More complex listings
 
 
-class _ListMarketBookParams(Params, frozen=True):
+class _ListMarketBookParams(Params, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     market_ids: list[str]  # One or more market ids
     price_projection: Optional[PriceProjection] = None  # The desired projection of price data
     order_projection: Optional[OrderProjection] = None  # The orders you want to receive in the response
@@ -144,7 +144,7 @@ class ListMarketBook(_ListingRequest, kw_only=True, frozen=True):
     return_type = Response[list[MarketBook]]
 
 
-class _ListMarketCatalogueParams(Params, kw_only=True, frozen=True):
+class _ListMarketCatalogueParams(Params, kw_only=True, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     filter: MarketFilter  # The filter to select desired markets
     market_projection: Optional[set[MarketProjection]] = None  # The type and amount of data returned about the market
     sort: Optional[MarketSort] = None  # The order of the results, defaults to RANK
@@ -169,7 +169,7 @@ class ListMarketCatalogue(_ListingRequest, kw_only=True, frozen=True):
 ListMarketCatalog = ListMarketCatalogue  # allow both spellings
 
 
-class _ListMarketProfitAndLossParams(Params, frozen=True):
+class _ListMarketProfitAndLossParams(Params, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     market_ids: set[MarketId]  # List of markets to calculate profit and loss
     include_settled_bets: Optional[bool] = False  # Option to include settled bets (partially settled markets only)
     include_bsp_bets: Optional[bool] = False  # Option to include BSP bets
@@ -183,7 +183,7 @@ class ListMarketProfitAndLoss(_ListingRequest, kw_only=True, frozen=True):
     return_type = Response[list[MarketProfitAndLoss]]
 
 
-class _ListRunnerBookParams(Params, frozen=True):
+class _ListRunnerBookParams(Params, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     market_id: MarketId  # The unique id for the market
     selection_id: SelectionId  # The unique id for the selection in the market
     handicap: Optional[Handicap] = None  # The handicap associated with the runner in case of Asian handicap market

--- a/betfair_parser/spec/betting/orders.py
+++ b/betfair_parser/spec/betting/orders.py
@@ -38,7 +38,7 @@ class _OrderRequest(Request, frozen=True, tag=betting_tag):
     endpoint_type = EndpointType.BETTING
 
 
-class _PlaceOrdersParams(Params, frozen=True):
+class _PlaceOrdersParams(Params, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     market_id: str
     instructions: list[PlaceInstruction]
     customer_ref: Optional[CustomerRef] = None
@@ -62,7 +62,7 @@ class PlaceOrders(_OrderRequest, kw_only=True, frozen=True):
     return_type = Response[PlaceExecutionReport]
 
 
-class _CancelOrdersParams(Params, frozen=True):
+class _CancelOrdersParams(Params, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     market_id: Optional[str] = None
     instructions: Optional[list[CancelInstruction]] = None
     customer_ref: Optional[CustomerRef] = None
@@ -78,7 +78,7 @@ class CancelOrders(_OrderRequest, kw_only=True, frozen=True):
     return_type = Response[CancelExecutionReport]
 
 
-class _ReplaceOrdersParams(Params, frozen=True):
+class _ReplaceOrdersParams(Params, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     market_id: str
     instructions: list[ReplaceInstruction]
     customer_ref: Optional[CustomerRef] = None
@@ -98,7 +98,7 @@ class ReplaceOrders(_OrderRequest, kw_only=True, frozen=True):
     return_type = Response[ReplaceExecutionReport]
 
 
-class _ListClearedOrdersParams(Params, frozen=True):
+class _ListClearedOrdersParams(Params, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     bet_status: BetStatus  # Restricts the results to the specified status.
     event_type_ids: Optional[set[EventTypeId]] = None  # Restricts the results to the specified Event Type IDs.
     event_ids: Optional[set[EventId]] = None  # Restricts the results to the specified Event IDs.
@@ -143,7 +143,7 @@ class ListClearedOrders(_OrderRequest, kw_only=True, frozen=True):
     return_type = Response[ClearedOrderSummaryReport]
 
 
-class _ListCurrentOrdersParams(Params, frozen=True):
+class _ListCurrentOrdersParams(Params, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """
     Parameters for retrieving a list of current orders.
     """
@@ -180,7 +180,7 @@ class ListCurrentOrders(_OrderRequest, kw_only=True, frozen=True):
     return_type = Response[CurrentOrderSummaryReport]
 
 
-class _UpdateOrdersParams(Params, frozen=True):
+class _UpdateOrdersParams(Params, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     market_id: str  # The market id these orders are to be placed on
     instructions: list[UpdateInstruction]  # The limit of update instructions per request is 60
     customer_ref: Optional[CustomerRef] = None

--- a/betfair_parser/spec/betting/type_definitions.py
+++ b/betfair_parser/spec/betting/type_definitions.py
@@ -110,7 +110,7 @@ class TimeRangeResult(BaseMessage, frozen=True):
     market_count: Optional[int] = None  # Count of markets associated with this TimeRange
 
 
-class MarketFilter(BaseMessage, omit_defaults=True, frozen=True):
+class MarketFilter(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     text_query: Optional[str] = None  # Restrict markets by any text associated with the Event name
     exchange_ids: Optional[set[ExchangeId]] = None  # DEPRECATED
     event_type_ids: Optional[set[EventTypeId]] = None  # Restrict markets by event type associated with the market
@@ -166,7 +166,7 @@ class ExchangePrices(BaseMessage, frozen=True):
     traded_volume: Optional[list[PriceSize]] = None
 
 
-class Order(BaseMessage, frozen=True):
+class Order(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     bet_id: BetId
     order_type: OrderType
     status: OrderStatus
@@ -216,7 +216,7 @@ class MarketLicence(BaseMessage, frozen=True):
     clarifications: Optional[str] = None  # Clarifications to the rules for the market
 
 
-class MarketDescription(BaseMessage, kw_only=True, frozen=True):
+class MarketDescription(BaseMessage, kw_only=True, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     persistence_enabled: bool  # Indicates if the market supports 'Keep' bets if turned in-play
     bsp_market: bool  # Indicates if the market supports Betfair SP betting
     market_time: Date  # Scheduled start time of the market
@@ -245,7 +245,7 @@ class MarketDescription(BaseMessage, kw_only=True, frozen=True):
 _MetaCountryCode = str  # CountryCode
 
 
-class RunnerMetaData(BaseMessage, frozen=True, omit_defaults=True, rename="upper"):
+class RunnerMetaData(BaseMessage, frozen=True, omit_defaults=True, repr_omit_defaults=True, rename="upper"):
     # Yes, this is the only type definition, that has (mostly) uppered key names
     """
     Runner metadata as defined in the API as additional information.
@@ -315,7 +315,7 @@ class RunnerMetaData(BaseMessage, frozen=True, omit_defaults=True, rename="upper
         return self.forecastprice_numerator / self.forecastprice_denominator + 1
 
 
-class RunnerCatalog(BaseMessage, frozen=True):
+class RunnerCatalog(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Information about the Runners (selections) in a market"""
 
     selection_id: int  # The unique id for the selection
@@ -332,7 +332,7 @@ class RunnerCatalog(BaseMessage, frozen=True):
         return self.runner_name
 
 
-class Runner(BaseMessage, frozen=True):
+class Runner(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """The dynamic data about runners in a market"""
 
     selection_id: int  # The unique id of the runner (selection)
@@ -349,7 +349,7 @@ class Runner(BaseMessage, frozen=True):
     matches_by_strategy: Optional[dict[str, list[Match]]] = None  # All matches for each strategy, sort by matched data
 
 
-class MarketCatalogue(BaseMessage, frozen=True):
+class MarketCatalogue(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     market_id: MarketId  # The unique identifier for the market
     market_name: str  # The name of the market
     market_start_time: Optional[Date] = None  # Only returned when the MARKET_START_TIME enum is requested
@@ -374,7 +374,7 @@ class KeyLineDescription(BaseMessage, frozen=True):
     key_line: list[KeyLineSelection]  # A list of KeyLineSelection objects
 
 
-class MarketBook(BaseMessage, frozen=True):
+class MarketBook(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """The dynamic data in a market"""
 
     market_id: MarketId  # The unique identifier for the market
@@ -397,7 +397,7 @@ class MarketBook(BaseMessage, frozen=True):
     key_line_description: Optional[KeyLineDescription] = None  # Description of a market's key line
 
 
-class ItemDescription(BaseMessage, frozen=True):
+class ItemDescription(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """
     This object contains some text which may be useful to render a betting history view.
     It offers no long-term warranty as to the correctness of the text.
@@ -413,7 +413,7 @@ class ItemDescription(BaseMessage, frozen=True):
     each_way_divisor: Optional[float] = None  # The divisor for the EACH_WAY market type
 
 
-class ClearedOrderSummary(BaseMessage, frozen=True):
+class ClearedOrderSummary(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Summary of a cleared order"""
 
     event_type_id: Optional[EventTypeId] = None  # The id of the event type bet on
@@ -465,7 +465,7 @@ class CurrentItemDescription(BaseMessage, frozen=True):
     market_version: MarketVersion  # The relevant version of the market for this item
 
 
-class CurrentOrderSummary(BaseMessage, frozen=True):
+class CurrentOrderSummary(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Summary of a current order"""
 
     bet_id: BetId  # The bet ID of the original place order
@@ -503,7 +503,7 @@ class CurrentOrderSummaryReport(BaseMessage, frozen=True):
     more_available: bool  # Indicates whether there are further result items beyond this page
 
 
-class LimitOrder(BaseMessage, omit_defaults=True, frozen=True):
+class LimitOrder(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Place a new LIMIT order (simple exchange bet for immediate execution)"""
 
     size: Size
@@ -524,7 +524,7 @@ class MarketOnCloseOrder(BaseMessage, frozen=True):
     liability: Size
 
 
-class PlaceInstruction(BaseMessage, kw_only=True, frozen=True):
+class PlaceInstruction(BaseMessage, kw_only=True, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Instruction to place a new order"""
 
     order_type: OrderType  # The order type
@@ -541,7 +541,7 @@ class PlaceInstruction(BaseMessage, kw_only=True, frozen=True):
     customer_order_ref: Optional[str] = None  # An optional reference to identify instructions
 
 
-class PlaceInstructionReport(BaseMessage, kw_only=True, frozen=True):
+class PlaceInstructionReport(BaseMessage, kw_only=True, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Report for a place instruction"""
 
     status: InstructionReportStatus  # The instruction report status
@@ -554,7 +554,7 @@ class PlaceInstructionReport(BaseMessage, kw_only=True, frozen=True):
     size_matched: Optional[Size] = None  # The current amount of the bet that was matched, if successful
 
 
-class PlaceExecutionReport(BaseMessage, kw_only=True, frozen=True):
+class PlaceExecutionReport(BaseMessage, kw_only=True, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     customer_ref: Optional[CustomerRef] = None  # Echo of the customer reference if passed
     status: ExecutionReportStatus  # The execution report status
     error_code: Optional[ExecutionReportErrorCode] = None  # The execution report error code
@@ -562,7 +562,7 @@ class PlaceExecutionReport(BaseMessage, kw_only=True, frozen=True):
     instruction_reports: Optional[list[PlaceInstructionReport]] = None  # The list of place instruction reports
 
 
-class CancelInstruction(BaseMessage, frozen=True):
+class CancelInstruction(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Instruction to fully or partially cancel an order (only applies to LIMIT orders)"""
 
     bet_id: BetId
@@ -578,7 +578,7 @@ class ReplaceInstruction(BaseMessage, frozen=True):
     new_price: Price  # The price to replace the bet at
 
 
-class CancelInstructionReport(BaseMessage, kw_only=True, frozen=True):
+class CancelInstructionReport(BaseMessage, kw_only=True, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     status: InstructionReportStatus  # Whether the command succeeded or failed
     error_code: Optional[InstructionReportErrorCode] = None  # Cause of failure, or null if command succeeds
     instruction: Optional[CancelInstruction] = None  # The instruction that was requested
@@ -586,7 +586,7 @@ class CancelInstructionReport(BaseMessage, kw_only=True, frozen=True):
     cancelled_date: Optional[Date] = None  # The API states, that this is mandatory, but it's skipped in case of error
 
 
-class CancelExecutionReport(BaseMessage, kw_only=True, frozen=True):
+class CancelExecutionReport(BaseMessage, kw_only=True, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     customer_ref: Optional[CustomerRef] = None  # Echo of the customerRef if passed
     status: ExecutionReportStatus
     error_code: Optional[ExecutionReportErrorCode] = None
@@ -594,14 +594,14 @@ class CancelExecutionReport(BaseMessage, kw_only=True, frozen=True):
     instruction_reports: Optional[list[CancelInstructionReport]] = None
 
 
-class ReplaceInstructionReport(BaseMessage, frozen=True):
+class ReplaceInstructionReport(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     status: InstructionReportStatus  # Whether the command succeeded or failed
     error_code: Optional[InstructionReportErrorCode] = None  # Cause of failure, or null if command succeeds
     cancel_instruction_report: Optional[CancelInstructionReport] = None  # Cancellation report for the original order
     place_instruction_report: Optional[PlaceInstructionReport] = None  # Placement report for the new order
 
 
-class ReplaceExecutionReport(BaseMessage, kw_only=True, frozen=True):
+class ReplaceExecutionReport(BaseMessage, kw_only=True, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     customer_ref: Optional[CustomerRef] = None  # Echo of the customerRef if passed.
     status: ExecutionReportStatus
     error_code: Optional[ExecutionReportErrorCode] = None
@@ -630,7 +630,7 @@ class UpdateExecutionReport(BaseMessage, frozen=True):
     instruction_reports: Optional[list[UpdateInstructionReport]]
 
 
-class ExBestOffersOverrides(BaseMessage, frozen=True):
+class ExBestOffersOverrides(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Options to alter the default representation of best offer prices"""
 
     best_prices_depth: Optional[int] = None  # The maximum number of prices to return on each side for each runner
@@ -640,7 +640,7 @@ class ExBestOffersOverrides(BaseMessage, frozen=True):
     rollup_liability_factor: Optional[int] = None  # Only applicable when rollupModel is MANAGED_LIABILITY
 
 
-class PriceProjection(BaseMessage, omit_defaults=True, frozen=True):
+class PriceProjection(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Selection criteria of the returning price data"""
 
     price_data: Optional[set[PriceData]] = None  # The basic price data you want to receive in the response
@@ -656,7 +656,7 @@ class PriceProjection(BaseMessage, omit_defaults=True, frozen=True):
     rollover_stakes: Optional[bool] = None
 
 
-class RunnerProfitAndLoss(BaseMessage, frozen=True):
+class RunnerProfitAndLoss(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Profit and loss if selection wins or loses"""
 
     selection_id: Optional[SelectionId] = None  # The unique identifier for the selection
@@ -667,7 +667,7 @@ class RunnerProfitAndLoss(BaseMessage, frozen=True):
     if_place: Optional[float] = None
 
 
-class MarketProfitAndLoss(BaseMessage, frozen=True):
+class MarketProfitAndLoss(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Profit and loss in a market"""
 
     market_id: Optional[MarketId] = None  # The unique identifier for the market

--- a/betfair_parser/spec/common/messages.py
+++ b/betfair_parser/spec/common/messages.py
@@ -50,7 +50,7 @@ class BaseMessage(msgspec.Struct, kw_only=True, forbid_unknown_fields=True, froz
         return msgspec.structs.replace(self, **kwargs)
 
 
-class Params(BaseMessage, omit_defaults=True, frozen=True):
+class Params(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """
     Base class for request parameters. Don't send None and other redundant default
     values. If not subclassed, this class is used to describe an empty parameter set.

--- a/betfair_parser/spec/streaming/messages.py
+++ b/betfair_parser/spec/streaming/messages.py
@@ -17,13 +17,13 @@ from betfair_parser.spec.streaming.type_definitions import (
 )
 
 
-class _StreamRequest(BaseMessage, tag_field="op", tag=first_lower, omit_defaults=True, frozen=True):
+class _StreamRequest(BaseMessage, tag_field="op", tag=first_lower, frozen=True):
     """Common parent class for any stream request."""
 
     id: Optional[Union[int, str]] = None  # Client generated unique id to link request with response (like json rpc)
 
 
-class _StreamResponse(BaseMessage, tag_field="op", tag=str.lower, omit_defaults=True, frozen=True):
+class _StreamResponse(BaseMessage, tag_field="op", tag=str.lower, frozen=True):
     """Common parent class for any stream response."""
 
     id: Optional[Union[int, str]] = None  # Client generated unique id to link request with response (like json rpc)
@@ -49,7 +49,7 @@ class _Subscription(_StreamRequest, kw_only=True, frozen=True):
     segmentation_enabled: bool = True  # allow server to send large sets of data in segments, instead of a single block
 
 
-class MarketSubscription(_Subscription, kw_only=True, frozen=True):
+class MarketSubscription(_Subscription, kw_only=True, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """
     This subscription type is used to receive price changes for one or more markets; your subscription
     criteria determine what you see. Limiting the amount of data that you consume will make your initial
@@ -60,7 +60,7 @@ class MarketSubscription(_Subscription, kw_only=True, frozen=True):
     market_data_filter: MarketDataFilter
 
 
-class OrderSubscription(_Subscription, kw_only=True, frozen=True):
+class OrderSubscription(_Subscription, kw_only=True, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """This subscription type is used to receive order changes."""
 
     order_filter: OrderFilter  # Optional filter applied to order subscription
@@ -79,7 +79,7 @@ class Connection(_StreamResponse, kw_only=True, frozen=True):
     connection_id: str  # Unique identifier for support queries
 
 
-class Status(_StreamResponse, kw_only=True, frozen=True):
+class Status(_StreamResponse, kw_only=True, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """Every request receives a status response with a matching id."""
 
     connection_closed: bool
@@ -125,7 +125,7 @@ class _ChangeMessage(_StreamResponse, kw_only=True, frozen=True):
         return self.pt
 
 
-class MCM(_ChangeMessage, kw_only=True, frozen=True):
+class MCM(_ChangeMessage, kw_only=True, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """
     This is the ChangeMessage stream of data Betfair sends back after subscribing to the market stream.
     Market subscriptions are always in the underlying exchange currency - GBP.
@@ -139,7 +139,7 @@ class MCM(_ChangeMessage, kw_only=True, frozen=True):
         return self.mc
 
 
-class OCM(_ChangeMessage, kw_only=True, frozen=True):
+class OCM(_ChangeMessage, kw_only=True, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     """
     This is the ChangeMessage stream of data Betfair sends back after subscribing to the order stream.
     Order subscriptions are provided in the currency of the account that the orders are placed in.

--- a/betfair_parser/spec/streaming/type_definitions.py
+++ b/betfair_parser/spec/streaming/type_definitions.py
@@ -24,7 +24,7 @@ from betfair_parser.spec.streaming.enums import LapseStatusReasonCode, MarketDat
 # Request objects
 
 
-class MarketFilter(BaseMessage, frozen=True):
+class MarketFilter(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     betting_types: Optional[list[MarketBettingType]] = None  # Match the betting type of the market
     bsp_market: Optional[bool] = None  # If set, restrict to BSP or non-BSP markets only. If unset, return both
     country_codes: Optional[list[str]] = None  # Restrict to specified country or countries. Defaults to 'GB' on error
@@ -37,7 +37,7 @@ class MarketFilter(BaseMessage, frozen=True):
     venues: Optional[list[Venue]] = None  # Restrict by the venue associated with the market. Only for horse racing
 
 
-class MarketDataFilter(BaseMessage, frozen=True):
+class MarketDataFilter(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     fields: Optional[list[MarketDataFilterFields]] = None
     ladder_levels: Optional[int] = None
 
@@ -58,7 +58,7 @@ class OrderFilter(BaseMessage, frozen=True):
 # Response objects
 
 
-class RunnerDefinition(BaseMessage, frozen=True):
+class RunnerDefinition(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     sort_priority: int
     id: SelectionId
     name: Optional[str] = None  # Undefined, but partly present
@@ -87,7 +87,7 @@ class PriceLadderDefinition(BaseMessage, frozen=True):
     type: PriceLadderDefinitionType
 
 
-class MarketDefinition(BaseMessage, kw_only=True, frozen=True):
+class MarketDefinition(BaseMessage, kw_only=True, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     bet_delay: int
     betting_type: MarketBettingType
     bsp_market: bool
@@ -168,7 +168,7 @@ StartingPriceLay = Annotated[PV, msgspec.Meta(title="StartingPriceLay")]
 Trade = Annotated[PV, msgspec.Meta(title="Trade")]
 
 
-class RunnerChange(BaseMessage, frozen=True):
+class RunnerChange(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     id: SelectionId
     atb: Optional[list[AvailableToBack]] = None
     atl: Optional[list[AvailableToLay]] = None
@@ -256,7 +256,7 @@ class RunnerChange(BaseMessage, frozen=True):
         return self.hc
 
 
-class MarketChange(BaseMessage, kw_only=True, frozen=True):
+class MarketChange(BaseMessage, kw_only=True, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     id: MarketId
     rc: Optional[list[RunnerChange]] = None  # Runner Changes
     con: Optional[bool] = None  # Conflated
@@ -285,7 +285,7 @@ class MarketChange(BaseMessage, kw_only=True, frozen=True):
         return self.tv
 
 
-class Order(BaseMessage, frozen=True):
+class Order(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     id: BetId
     p: float  # Price
     s: float  # Size
@@ -430,7 +430,7 @@ class MatchedOrder(BaseMessage, array_like=True, frozen=True):
     size: Size
 
 
-class StrategyMatchChange(BaseMessage, frozen=True):
+class StrategyMatchChange(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     mb: Optional[list[MatchedOrder]] = None  # Matched Backs
     ml: Optional[list[MatchedOrder]] = None  # Matched Lays
 
@@ -445,7 +445,7 @@ class StrategyMatchChange(BaseMessage, frozen=True):
         return self.ml
 
 
-class OrderRunnerChange(BaseMessage, frozen=True):
+class OrderRunnerChange(BaseMessage, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     id: SelectionId
     full_image: Optional[bool] = False
     hc: Optional[Handicap] = None
@@ -480,7 +480,7 @@ class OrderRunnerChange(BaseMessage, frozen=True):
         return self.uo
 
 
-class OrderMarketChange(BaseMessage, kw_only=True, frozen=True):
+class OrderMarketChange(BaseMessage, kw_only=True, omit_defaults=True, repr_omit_defaults=True, frozen=True):
     id: MarketId
     account_id: Optional[int] = None
     closed: Optional[bool] = None

--- a/tests/resources/__init__.py
+++ b/tests/resources/__init__.py
@@ -20,10 +20,10 @@ def _parse_json_date(datetime_str):
 def assert_json_equal(x, y):
     assert type(x) == type(y)
     if isinstance(x, dict):
-        assert len(x) == len(y)
+        # can't compare the length, as None values might have been omitted
+        assert sum(1 for v in x.values() if v is not None) == sum(1 for v in y.values() if v is not None)
         for key_x in x:
-            assert key_x in y
-            assert_json_equal(x[key_x], y[key_x])
+            assert_json_equal(x[key_x], y.get(key_x))
     elif isinstance(x, list):
         assert len(x) == len(y)
         for item_x, item_y in zip(x, y):


### PR DESCRIPTION
- All objects with defaults and all defaults being `None` now use `repr_omit_defaults` and `omit_defaults`. Unfortunately this needs to be set on all classes individually. 
- `omit_defaults` skips default values in outgoing messages, reducing bandwidth usage and marginally increasing transaction speed. 
- `repr_omit_defaults` skips all the empty fields from being printed in object representations, making them easier to read.
- Fixes #54